### PR TITLE
Fix compilation issue with MSVC

### DIFF
--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -20,6 +20,8 @@
 #include <ScriptBindings/Config.h>
 #include <ScriptBindings/ScriptFunction.h>
 
+#include <Client/Fonts.h>
+
 #include "ConfigConsoleResponder.h"
 #include "ConsoleCommand.h"
 #include "ConsoleHelper.h"


### PR DESCRIPTION
This commit fixes a compilation issue caused by the use of an incomplete type
`FontManager` in an instantiation of `Handle<FontManager>::~Handle()`.

Fixes #852.